### PR TITLE
Add category pages.

### DIFF
--- a/_includes/post-header.html
+++ b/_includes/post-header.html
@@ -1,6 +1,9 @@
 <!-- Feel free to remove this div. Uses purplecoat: http://ellekasai.github.io/purplecoat.js -->
 <div data-purplecoat="shiori" data-purplecoat-label="post-header.html">
 <p class="text-muted">{{ page.date | date_to_string }}</p>
+{% if page.categories != empty %}
+<p class="text-muted">Filed under {{ page.categories | category_links }}</p>
+{% endif %}
 <div class="well well-sm">
   {% include ribbon.html %} You can customize this section in <code>_includes</code> &rarr; <code>post-header.html</code>.
 </div>

--- a/_layouts/category_index.html
+++ b/_layouts/category_index.html
@@ -1,0 +1,12 @@
+---
+layout: default
+---
+
+<h1 class="category">{{ page.title }}</h1>
+<ul class="posts">
+{% for post in site.categories[page.category] %}
+    <li><a class="post-title-archive" href="{{ post.url | prepend:site.baseurl }}">{{ post.title }}</a>
+    <small class="text-muted">{{ post.date | date_to_string }}</small>
+    </li>
+{% endfor %}
+</ul>

--- a/_plugins/generate_categories.rb
+++ b/_plugins/generate_categories.rb
@@ -1,0 +1,293 @@
+# encoding: utf-8
+#
+# Jekyll category page generator.
+# http://recursive-design.com/projects/jekyll-plugins/
+#
+# Version: 0.2.4 (201210160037)
+#
+# Copyright (c) 2010 Dave Perrett, http://recursive-design.com/
+# Licensed under the MIT license (http://www.opensource.org/licenses/mit-license.php)
+#
+# A generator that creates category pages for jekyll sites.
+#
+# To use it, simply drop this script into the _plugins directory of your Jekyll site. You should
+# also create a file called 'category_index.html' in the _layouts directory of your jekyll site
+# with the following contents (note: you should remove the leading '# ' characters):
+#
+# ================================== COPY BELOW THIS LINE ==================================
+# ---
+# layout: default
+# ---
+#
+# <h1 class="category">{{ page.title }}</h1>
+# <ul class="posts">
+# {% for post in site.categories[page.category] %}
+#     <div>{{ post.date | date_to_html_string }}</div>
+#     <h2><a href="{{ post.url }}">{{ post.title }}</a></h2>
+#     <div class="categories">Filed under {{ post.categories | category_links }}</div>
+# {% endfor %}
+# </ul>
+# ================================== COPY ABOVE THIS LINE ==================================
+#
+# You can alter the _layout_ setting if you wish to use an alternate layout, and obviously you
+# can change the HTML above as you see fit.
+#
+# When you compile your jekyll site, this plugin will loop through the list of categories in your
+# site, and use the layout above to generate a page for each one with a list of links to the
+# individual posts.
+#
+# You can also (optionally) generate an atom.xml feed for each category. To do this, copy
+# the category_feed.xml file to the _includes/custom directory of your own project
+# (https://github.com/recurser/jekyll-plugins/blob/master/_includes/custom/category_feed.xml).
+# You'll also need to copy the octopress_filters.rb file into the _plugins directory of your
+# project as the category_feed.xml requires a couple of extra filters
+# (https://github.com/recurser/jekyll-plugins/blob/master/_plugins/octopress_filters.rb).
+#
+# Included filters :
+# - category_links:      Outputs the list of categories as comma-separated <a> links.
+# - date_to_html_string: Outputs the post.date as formatted html, with hooks for CSS styling.
+#
+# Available _config.yml settings :
+# - category_dir:          The subfolder to build category pages in (default is 'categories').
+# - category_title_prefix: The string used before the category name in the page title (default is
+#                          'Category: ').
+module Jekyll
+  module Utils
+    # Like slugify, but doesn't clobber symbols that I care about.
+    #
+    #  +category+ the category string
+    #
+    # Return string
+    def slugify_category(category)
+      # Special-case certain symbols before slugging
+      category = category.gsub(/\+/, 'plus')
+      category = category.gsub(/#/, 'sharp')
+      category = Utils.slugify(category)
+      category
+    end
+  end # module Utils
+
+  # The CategoryIndex class creates a single category page for the specified category.
+  class CategoryPage < Page
+
+    # Initializes a new CategoryIndex.
+    #
+    #  +template_path+ is the path to the layout template to use.
+    #  +site+          is the Jekyll Site instance.
+    #  +base+          is the String path to the <source>.
+    #  +category_dir+  is the String path between <source> and the category folder.
+    #  +category+      is the category currently being processed.
+    def initialize(template_path, name, site, base, category_dir, category)
+      @site  = site
+      @base  = base
+      @dir   = category_dir
+      @name  = name
+
+      self.process(name)
+
+      if File.exist?(template_path)
+        @perform_render = true
+        template_dir    = File.dirname(template_path)
+        template        = File.basename(template_path)
+        # Read the YAML data from the layout page.
+        self.read_yaml(template_dir, template)
+        self.data['category']    = category
+        # Set the title for this page.
+        title_prefix             = site.config['category_title_prefix'] || 'Category: '
+        capitalized_category = category.split(' ').each { |word|
+            word.capitalize!
+        }.join(' ')
+        self.data['title']       = "#{title_prefix}#{capitalized_category}"
+        # Set the meta-description for this page.
+        meta_description_prefix  = site.config['category_meta_description_prefix'] || 'Category: '
+        self.data['description'] = "#{meta_description_prefix}#{category}"
+      else
+        @perform_render = false
+      end
+    end
+
+    def render?
+      @perform_render
+    end
+
+  end
+
+  # The CategoryIndex class creates a single category page for the specified category.
+  class CategoryIndex < CategoryPage
+
+    # Initializes a new CategoryIndex.
+    #
+    #  +site+         is the Jekyll Site instance.
+    #  +base+         is the String path to the <source>.
+    #  +category_dir+ is the String path between <source> and the category folder.
+    #  +category+     is the category currently being processed.
+    def initialize(site, base, category_dir, category)
+      template_path = File.join(base, '_layouts', 'category_index.html')
+      super(template_path, 'index.html', site, base, category_dir, category)
+    end
+
+  end
+
+  # The CategoryFeed class creates an Atom feed for the specified category.
+  class CategoryFeed < CategoryPage
+
+    # Initializes a new CategoryFeed.
+    #
+    #  +site+         is the Jekyll Site instance.
+    #  +base+         is the String path to the <source>.
+    #  +category_dir+ is the String path between <source> and the category folder.
+    #  +category+     is the category currently being processed.
+    def initialize(site, base, category_dir, category)
+      template_path = File.join(base, '_includes', 'custom', 'category_feed.xml')
+      super(template_path, 'atom.xml', site, base, category_dir, category)
+
+      # Set the correct feed URL.
+      self.data['feed_url'] = "#{category_dir}/#{name}" if render?
+    end
+
+  end
+
+  # The Site class is a built-in Jekyll class with access to global site config information.
+  class Site
+
+    # Creates an instance of CategoryIndex for each category page, renders it, and
+    # writes the output to a file.
+    #
+    #  +category+ is the category currently being processed.
+    def write_category_index(category)
+      target_dir = GenerateCategories.category_dir(self.config['category_dir'], category)
+      index      = CategoryIndex.new(self, self.source, target_dir, category)
+      if index.render?
+        index.render(self.layouts, site_payload)
+        index.write(self.dest)
+        # Record the fact that this pages has been added, otherwise Site::cleanup will remove it.
+        self.pages << index
+      end
+
+      # Create an Atom-feed for each index.
+      feed = CategoryFeed.new(self, self.source, target_dir, category)
+      if feed.render?
+        feed.render(self.layouts, site_payload)
+        feed.write(self.dest)
+        # Record the fact that this pages has been added, otherwise Site::cleanup will remove it.
+        self.pages << feed
+      end
+    end
+
+    # Loops through the list of category pages and processes each one.
+    def write_category_indexes
+      if self.layouts.key? 'category_index'
+        self.categories.keys.each do |category|
+          self.write_category_index(category)
+        end
+
+      # Throw an exception if the layout couldn't be found.
+      else
+        throw "No 'category_index' layout found."
+      end
+    end
+
+  end
+
+
+  # Jekyll hook - the generate method is called by jekyll, and generates all of the category pages.
+  class GenerateCategories < Generator
+    safe true
+    priority :low
+
+    CATEGORY_DIR = 'categories'
+
+    def generate(site)
+      site.write_category_indexes
+    end
+
+    # Processes the given dir and removes leading and trailing slashes. Falls
+    # back on the default if no dir is provided.
+    def self.category_dir(base_dir, category)
+      base_dir = (base_dir || CATEGORY_DIR).gsub(/^\/*(.*)\/*$/, '\1')
+
+      # Special-case certain symbols before slugging
+      #category = category.gsub(/\+/, 'plus')
+      #category = category.gsub(/#/, 'sharp')
+      #category = Utils.slugify(category)
+      category = Utils.slugify_category(category)
+      #category = category.gsub(/_|\P{Word}/, '-').gsub(/-{2,}/, '-').downcase
+
+      File.join(base_dir, category)
+    end
+
+  end
+
+
+  # Adds some extra filters used during the category creation process.
+  module Filters
+
+    # Outputs a list of categories as comma-separated <a> links. This is used
+    # to output the category list for each post on a category page.
+    #
+    #  +categories+ is the list of categories to format.
+    #
+    # Returns string
+    def category_links(categories)
+      baseurl = @context.registers[:site].config['baseurl']
+      base_dir = @context.registers[:site].config['category_dir']
+      categories = categories.sort!.map do |category|
+        capitalized_category = category.split(' ').each { |word|
+            word.capitalize!
+        }.join(' ')
+        #category_dir = GenerateCategories.category_dir(base_dir, category)
+        # Make sure the category directory begins with a slash.
+        #category_dir = "/#{category_dir}" unless category_dir =~ /^\//
+        #case baseurl
+        #when ''
+        #  category_dir = "/#{category_dir}" #unless category_dir =~ /^\//
+        #else
+        #  category_dir = "#{baseurl}/#{category_dir}" #unless category_dir =~ /^\//
+        #end
+        category_dir = category_link(category)
+        "<a class='category' href='#{category_dir}/'>#{capitalized_category}</a>"
+      end
+
+      case categories.length
+      when 0
+        ""
+      when 1
+        categories[0].to_s
+      else
+        categories.join(', ')
+      end
+    end
+
+    # Returns the category link name corresponding to the given category name.
+    #
+    #  +category+ the name of the category to format
+    #
+    # Returns string
+    def category_link(category)
+      baseurl = @context.registers[:site].config['baseurl']
+      base_dir = @context.registers[:site].config['category_dir']
+      category_dir = GenerateCategories.category_dir(base_dir, category)
+      case baseurl
+      when ''
+        category_dir = "/#{category_dir}"
+      else
+        category_dir = "#{baseurl}/#{category_dir}"
+      end
+      category_dir
+    end
+
+    # Outputs the post.date as formatted html, with hooks for CSS styling.
+    #
+    #  +date+ is the date object to format as HTML.
+    #
+    # Returns string
+    def date_to_html_string(date)
+      result = '<span class="month">' + date.strftime('%b').upcase + '</span> '
+      result += date.strftime('<span class="day">%d</span> ')
+      result += date.strftime('<span class="year">%Y</span> ')
+      result
+    end
+
+  end
+
+end

--- a/_posts/2014-06-28-example-bootstrap.md
+++ b/_posts/2014-06-28-example-bootstrap.md
@@ -1,5 +1,6 @@
 ---
 title: "Shiori by Example: Helpful Bootstrap Components"
+categories: [Bootstrap, shiori]
 ---
 
 With Shiori, you can take advantage of all the available components in Bootstrap. Here are some useful components for blogging.

--- a/_posts/2014-07-27-exmaple-css.md
+++ b/_posts/2014-07-27-exmaple-css.md
@@ -1,5 +1,6 @@
 ---
 title: "Shiori by Example: Fundamental HTML Elements"
+categories: [Shiori, CSS, HTML]
 ---
 
 Shiori uses [Bootstrap](http://getbootstrap.com/) for styling. Here's how fundamental HTML elements are displayed on Shiori. To learn more, check out Bootstrap's [documentation](http://getbootstrap.com/css/).

--- a/_posts/2014-07-28-introducing-shiori.md
+++ b/_posts/2014-07-28-introducing-shiori.md
@@ -1,5 +1,6 @@
 ---
 title: "Introducing Shiori: A Bootstrap-Based Jekyll Theme"
+categories: [shiori]
 ---
 
 ![Shiori](https://cloud.githubusercontent.com/assets/992008/3955483/2b9a77ae-2702-11e4-9f28-6afb051271de.png)

--- a/_posts/2015-01-03-categories-in-shiori.md
+++ b/_posts/2015-01-03-categories-in-shiori.md
@@ -1,0 +1,50 @@
+---
+title: "Categories in Shiori"
+categories: [shiori, html, bootstrap, category with spaces]
+---
+
+## Overview
+It's nice to categorize your posts so you can browse related posts more easily.
+
+1. We use a plugin to generate category pages. The categories will be placed in <code>/categories/&lt;category_name&gt;</code>.
+2. We define <code>category_links</code> and <code>category_link</code> filters to create links to category pages.
+
+## Example
+The list of categories for a post in the header above is generated like this:
+
+~~~~~~~~~~~~
+{{ "{% if page.categories != empty" }} %}
+<p class="text-muted">Filed under {{ "{{ page.categories | category_links" }}}}</p>
+{{ "{% endif" }} %}
+~~~~~~~~~~~~
+
+You can link to a single existing category page, for example,
+
+~~~~~~~~~~~~
+<a href="{{ "{{ 'html' | category_link " }}}}">HTML</a>
+~~~~~~~~~~~~
+
+will produce this link: <a href="{{ 'html' | category_link }}">HTML</a>.
+
+We can make a list of all categories like this:
+
+~~~~~~~~~~~~
+<ul>
+{{ "{% assign sorted_categories = site.categories | sort" }} %}
+{{ "{% for category in sorted_categories" }} %}
+<li><a href="{{ "{{ category | first | category_link" }}}}">{{ "{{ category | first | capitalize" }}}}</a></li>
+{{ "{% endfor" }} %}
+</ul>
+~~~~~~~~~~~~
+
+<ul>
+{% assign sorted_categories = site.categories | sort %}
+{% for category in sorted_categories %}
+<li><a href="{{ category | first | category_link }}">{{ category | first | capitalize }}</a></li>
+{% endfor %}
+</ul>
+
+## Limitation
+* Because we use Jekyll plugin, this doesn't work automatically with Github Pages. You need to generate the site and push that to your <code>gh-pages</code> branch instead.
+* Categories seem to be case-insensitive, so it might be hard to style them consistently.
+* Categories with symbols might not work properly. Please modify the <code>slugify_category</code> method in <code>_plugins/generate_categories.rb</code> for yourself.


### PR DESCRIPTION
Hi,

I like using Shiori theme but wanted category pages, so I added this. What do you think? Here's a [demo](http://alextsui05.github.io/shiori/categories-in-shiori/).

Pages will be generated for each category and list all posts with that
category. Posts that specify a list of categories in the front matter will
be linked to the corresponding category pages.
- Import and modify generate_categories.rb from recurser/jekyll-plugins.
  It generates /categories/#{category}/index.html for each category.
  These pages list all posts that have that category.
- Modify post-header.html to print a post's categories, if available.
- Add category_index.html, the layout used by the category pages.
- Add categories to example pages to demonstrate.
- Add an example post to demonstrate how to use it.
