### PR TITLE
Fix missing jekyll-gist gem in _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,6 +7,7 @@ title: "Shiori"
 
 gems:
   - jemoji
+  - jekyll-gist
 exclude:
   - "README.md"
   - "CHANGELOG.md"


### PR DESCRIPTION
Without `jekyll-gist`, I get this error:
```
$ bundle exec jekyll s
Configuration file: /home/indrakaw/html/shiori/_config.yml
Configuration file: /home/indrakaw/html/shiori/_config.yml
            Source: /home/indrakaw/html/shiori
       Destination: /home/indrakaw/html/shiori/_site
 Incremental build: disabled. Enable with --incremental
      Generating... 
  Liquid Exception: Liquid syntax error (line 58): Unknown tag 'gist' in /home/indrakaw/html/shiori/_posts/2014-0
```